### PR TITLE
Remove cross-platform related todo

### DIFF
--- a/generators/app/templates/bin/build-docker
+++ b/generators/app/templates/bin/build-docker
@@ -7,8 +7,7 @@
 set -o nounset
 [ "${CI_SERVER:-}" = "yes" ] && set -x
 
-# TODO: enable cross-platform compatibility with macOS
-root="$(readlink -f "$(dirname "$0")" | sed -r 's/\/bin.*//')"
+root="$(dirname "$0")/.."
 image="$(eval echo "$(cat tag)")"
 version="$(cat "${root}/version")"
 release_date="$(date +%Y-%m-%d:%H:%M)"


### PR DESCRIPTION
remove sed as the flags on macOS and gnu behave differently